### PR TITLE
adding pretty: true to the mailer options

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,8 @@ function getTemplatePart( mail, template ) {
 	var promise = new promise_io.Promise();
 	var options = {
 		cache: true,
-		filename: templateFile
+		filename: templateFile,
+		pretty: true // need this to adhere to SMTP line-length
 	};
 	var functionCacheKey = JSON.stringify( options ); // templates are actually compiled into a javascript function for rendering, and are cached here
 


### PR DESCRIPTION
SMTP requires that a line cannot be more than 1000 characters.  When this occurs, Mandrill (probably others), inserts a newline break every 1000 characters.  This was happening inside a link href, which was breaking the link.

Adding {pretty: true} to the jade compile options makes jade insert line breaks where there are <br> elements.

Anthony, fix this now!@!@#$!%$#$%^#@!
